### PR TITLE
ci: Improve test directory structure

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,7 +31,7 @@ jobs:
         cd test_output
         python3 -m coverage run --branch --parallel-mode ../tests/test.py -c # This uses the coverage module under the hood to gain coverage info of invoked subprocesses
         python3 -m coverage run --branch --parallel-mode ../tests/test_cpp_symbols.py
-        python3 -m coverage combine *
+        python3 -m coverage combine * */*
         python3 -m coverage xml
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Tests whose ficture class is derived from TestCaseWithSubdirs
will now generate any test output in a directory structure
where the top level directory matches the fixture class
name and the subdirectories the test method names
of the fixture.