### PR TITLE
Fixed typo when setting Symbol type_

### DIFF
--- a/src/elf_diff/binary.py
+++ b/src/elf_diff/binary.py
@@ -338,11 +338,11 @@ class Binary(object):
                     )
                     if data_symbol is not None:
                         data_symbol.size = int(symbol_size_str)
-                        data_symbol.type = symbol_type
+                        data_symbol.type_ = symbol_type
                         self.addSymbol(data_symbol)
                 else:
                     self.symbols[symbol_name].size = int(symbol_size_str)
-                    self.symbols[symbol_name].type = symbol_type
+                    self.symbols[symbol_name].type_ = symbol_type
 
     def parseSymbols(self):
 


### PR DESCRIPTION
Was causing the symbol type to show as '?' in reports because the default value was not being set.