### PR TITLE
Handle `driver_file is None`

### DIFF
--- a/src/elf_diff/settings.py
+++ b/src/elf_diff/settings.py
@@ -342,7 +342,7 @@ class Settings(object):
         self.old_alias: Optional[str] = None
         self.new_alias: Optional[str] = None
 
-        if hasattr(cmd_line_args, "driver_file"):
+        if hasattr(cmd_line_args, "driver_file") and cmd_line_args.driver_file:
             self.driver_file = cmd_line_args.driver_file
             self._readDriverFile()
 


### PR DESCRIPTION
With Python 3.11 the command line args include driver_file but it's None. It then errors trying to load from None. This guards against that.