### PR TITLE
feat: support script mode in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,5 +42,9 @@ install_requires =
   dict2xml
 python_requires = >=3.6
 
+[options.entry_points]
+console_scripts =
+    elf_diff = elf_diff.__main__:main
+
 [options.packages.find]
 where=src


### PR DESCRIPTION
Add the entry needed to run as a console script. This enables usage models like so:

```bash
pip install elf-diff

# run the script standalone, without python -m
elf_diff ...

# use uvx to run the script in one shot
uvx elf_diff ...
```

For testing, `uvx` can be invoked like so locally:

```bash
uvx --no-cache --from . -- \
  elf-diff --html_dir report tests/x86_64/libelf_diff_test_debug_old.a tests/x86_64/libelf_diff_test_debug_new.a
```